### PR TITLE
Feature: Backend Multi-Site Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@medusajs/cache-redis": "^1.8.4",
     "@medusajs/event-bus-local": "^1.9.1",
     "@medusajs/event-bus-redis": "^1.8.4",
-    "@medusajs/medusa": "1.11.0",
+    "@medusajs/medusa": "1.12.0",
     "@medusajs/medusa-cli": "^1.3.12",
     "babel-preset-medusa-package": "^1.1.13",
     "body-parser": "^1.19.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,10 @@
 import { Router } from "express"
+import { registerSalesChannel } from "./middlewares/sales-channel"
 
 export default (rootDirectory: string): Router | Router[] => {
-  // add your custom routes here
-  return []
+  // Custom routes
+  const router = Router()
+  router.use(registerSalesChannel)
+
+  return router
 }

--- a/src/api/middlewares/sales-channel.ts
+++ b/src/api/middlewares/sales-channel.ts
@@ -1,0 +1,15 @@
+import { Lifetime } from "awilix"
+
+export async function registerSalesChannel(req, res, next) {
+  // Retrieve Sales Channel from the request header 
+  const salesChannel = req.header("sales_channel_id")
+  
+  // Register the Sales Channel
+  req.scope.register({
+    salesChannel: {
+      resolve: () => salesChannel,
+    },
+  })
+  
+  next()
+}

--- a/src/migrations/1685018915459-add-customer-sales-channel-id.ts
+++ b/src/migrations/1685018915459-add-customer-sales-channel-id.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddCustomerSalesChannelId1685018915459 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "customer" ADD "sales_channel_id" character varying`);
+        await queryRunner.query(`CREATE INDEX "CustomerSalesChannelId" ON "customer" ("sales_channel_id") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."CustomerSalesChannelId"`);
+        await queryRunner.query(`ALTER TABLE "customer" DROP COLUMN "sales_channel_id"`);
+    }
+
+}

--- a/src/migrations/1685018915459-add-customer-sales-channel-id.ts
+++ b/src/migrations/1685018915459-add-customer-sales-channel-id.ts
@@ -11,5 +11,4 @@ export class AddCustomerSalesChannelId1685018915459 implements MigrationInterfac
         await queryRunner.query(`DROP INDEX "public"."CustomerSalesChannelId"`);
         await queryRunner.query(`ALTER TABLE "customer" DROP COLUMN "sales_channel_id"`);
     }
-
 }

--- a/src/migrations/1685018915459-add-customer-sales-channel-id.ts
+++ b/src/migrations/1685018915459-add-customer-sales-channel-id.ts
@@ -4,11 +4,15 @@ export class AddCustomerSalesChannelId1685018915459 implements MigrationInterfac
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "customer" ADD "sales_channel_id" character varying`);
+        await queryRunner.query(`ALTER TABLE "customer" DROP CONSTRAINT "UQ_unique_email_for_guests_and_customer_accounts"`);
+        await queryRunner.query(`ALTER TABLE "customer" ADD CONSTRAINT "UQ_unique_email_sales_channel" UNIQUE (email, has_account, sales_channel_id)`);
         await queryRunner.query(`CREATE INDEX "CustomerSalesChannelId" ON "customer" ("sales_channel_id") `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`DROP INDEX "public"."CustomerSalesChannelId"`);
+        await queryRunner.query(`ALTER TABLE "customer" DROP CONSTRAINT "UQ_unique_email_sales_channel"`);
+        await queryRunner.query(`ALTER TABLE "customer" ADD CONSTRAINT "UQ_unique_email_for_guests_and_customer_accounts" UNIQUE (email, has_account)`);
         await queryRunner.query(`ALTER TABLE "customer" DROP COLUMN "sales_channel_id"`);
     }
 }

--- a/src/models/customer.ts
+++ b/src/models/customer.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm"
+import { Customer as MedusaCustomer } from "@medusajs/medusa"
+import { SalesChannel } from "@medusajs/medusa"
+
+@Entity()
+export class Customer extends MedusaCustomer {
+  @Index("CustomerSalesChannelId")
+  @Column({ nullable: true })
+  sales_channel_id?: string;
+}

--- a/src/repositories/customer.ts
+++ b/src/repositories/customer.ts
@@ -1,0 +1,14 @@
+import { Customer } from "../models/customer"
+import { dataSource } from "@medusajs/medusa/dist/loaders/database"
+import { CustomerRepository as MedusaCustomerRepository } from "@medusajs/medusa/dist/repositories/customer"
+
+export const CustomerRepository = dataSource
+  .getRepository(Customer)
+  .extend({
+    ...Object.assign(
+      MedusaCustomerRepository, 
+      { target: Customer }
+    ),
+  })
+
+export default CustomerRepository

--- a/src/scripts/debug.ts
+++ b/src/scripts/debug.ts
@@ -1,0 +1,6 @@
+export function debugLog(...args: any[]): void {
+  const debug = process.env.DEBUG_MODE === "true";
+  if (debug) {
+    console.log("DEBUG:",...args);
+  }
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,6 +3,7 @@ import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth"
 import { Customer } from "../models/customer"
 import CustomerService from "../services/customer"
 import { AuthService as MedusaAuthService } from "@medusajs/medusa"
+import { debugLog } from "../scripts/debug"
 
 type InjectedDependencies = {
   customerService: CustomerService
@@ -38,6 +39,7 @@ class AuthService extends MedusaAuthService {
     email: string,
     password: string
   ): Promise<AuthenticateResult> {
+    debugLog("running authenticateCustomer", "email:", email, "password:", password)
     return await this.atomicPhase_(async (transactionManager) => {
       try {
         const sC = this.customerService_.updateBillingAddress_

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,78 @@
+import { Lifetime } from "awilix"
+import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth"
+import { Customer } from "../models/customer"
+import CustomerService from "../services/customer"
+import { AuthService as MedusaAuthService } from "@medusajs/medusa"
+
+type InjectedDependencies = {
+  customerService: CustomerService
+}
+
+class AuthService extends MedusaAuthService {
+  static LIFE_TIME = Lifetime.SCOPED
+  protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base AuthService
+  protected readonly salesChannel_: string | null = null;
+
+  constructor( dependencies: InjectedDependencies ) {
+    // @ts-expect-error prefer-rest-params
+    super(...arguments)
+    
+    try {
+      this.customerService_ = dependencies.customerService
+    } catch (e) {
+      // avoid errors when backend first runs
+    }
+  }
+
+  /**
+   * Authenticates a customer based on an email, password combination. Uses
+   * scrypt to match password with hashed value. Extended from medusa core to 
+   * retrieve customer matching the sales channel provided in the header.
+   * @param {string} email - the email of the user
+   * @param {string} password - the password of the user
+   * @return {{ success: (bool), customer: (object | undefined) }}
+   *    success: whether authentication succeeded
+   *    user: the user document if authentication succeded
+   *    error: a string with the error message
+   */
+  async authenticateCustomer(
+    email: string,
+    password: string
+  ): Promise<AuthenticateResult> {
+    return await this.atomicPhase_(async (transactionManager) => {
+      try {
+        const sC = this.customerService_.updateBillingAddress_
+        const customer: Customer = await this.customerService_
+          .withTransaction(transactionManager)
+          .retrieveRegisteredByEmailAndSalesChannel(email, {
+            select: ["id", "password_hash"],
+          })
+        if (customer.password_hash) {
+          const passwordsMatch = await this.comparePassword_(
+            password,
+            customer.password_hash
+          )
+
+          if (passwordsMatch) {
+            const customer = await this.customerService_
+              .withTransaction(transactionManager)
+              .retrieveRegisteredByEmailAndSalesChannel(email)
+            return {
+              success: true,
+              customer,
+            }
+          }
+        }
+      } catch (error) {
+        // ignore
+      }
+
+      return {
+        success: false,
+        error: "Invalid email or password",
+      }
+    })
+  }
+}
+
+export default AuthService

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -39,7 +39,8 @@ class AuthService extends MedusaAuthService {
     email: string,
     password: string
   ): Promise<AuthenticateResult> {
-    debugLog("running authenticateCustomer", "email:", email, "password:", password)
+    debugLog("authenticateCustomer running...")
+    debugLog("email:", email, "password:", password)
     return await this.atomicPhase_(async (transactionManager) => {
       try {
         const sC = this.customerService_.updateBillingAddress_

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -11,7 +11,6 @@ type InjectedDependencies = {
 class AuthService extends MedusaAuthService {
   static LIFE_TIME = Lifetime.SCOPED
   protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base AuthService
-  protected readonly salesChannel_: string | null = null;
 
   constructor( dependencies: InjectedDependencies ) {
     // @ts-expect-error prefer-rest-params

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -6,13 +6,16 @@ import { CartService as MedusaCartService } from "@medusajs/medusa"
 // extra imports for create function
 import {
   CartCreateProps,
+  CartUpdateProps
 } from "@medusajs/medusa/dist/types/cart"
 import {
   Cart,
+  DiscountRuleType
 } from "@medusajs/medusa/dist/models"
 import { DeepPartial, EntityManager } from "typeorm"
 import SalesChannelFeatureFlag from "@medusajs/medusa/dist/loaders/feature-flags/sales-channels"
 import { isDefined, MedusaError } from "medusa-core-utils"
+import { setMetadata } from "@medusajs/medusa/dist/utils"
 
 type InjectedDependencies = {
   customerService: CustomerService
@@ -45,11 +48,10 @@ class CartService extends MedusaCartService {
     sales_channel_id: string,
   ): Promise<Customer> {
     
-  	console.log("createOrFetchGuestCustomerFromEmail_ running...")
+  	console.log("createOrFetchGuestCustomerFromEmailAndSalesChannel_ running...")
   	console.log("email: ", email)
   	console.log("sales channel id: ", sales_channel_id)
   	
-    
     const validatedEmail = validateEmail(email)
     const salesChannelId = sales_channel_id
 
@@ -62,7 +64,7 @@ class CartService extends MedusaCartService {
       .catch(() => undefined)
 
     if (!customer) {
-      customer = await customerServiceTx.create({ email: validatedEmail })
+      customer = await customerServiceTx.create({ email: validatedEmail, sales_channel_id: salesChannelId })
     }
 
 	/*console.log("Email:", email);
@@ -87,11 +89,13 @@ class CartService extends MedusaCartService {
         const addressRepo = transactionManager.withRepository(
           this.addressRepository_
         )
+        console.log("grabbing raw cart?...")
 
         const rawCart: DeepPartial<Cart> = {
           context: data.context ?? {},
         }
-
+        
+        console.log("grabbing sales channel?...", rawCart)
         if (
           this.featureFlagRouter_.isFeatureEnabled(SalesChannelFeatureFlag.key)
         ) {
@@ -100,6 +104,7 @@ class CartService extends MedusaCartService {
           ).id
         }
 
+        console.log("grabbing customer details?...", data)
         if (data.customer_id) {
           const customer = await this.customerService_
             .withTransaction(transactionManager)
@@ -109,9 +114,10 @@ class CartService extends MedusaCartService {
           rawCart.customer_id = customer?.id
           rawCart.email = customer?.email
         }
-
+        
+        console.log(rawCart, data)
         if (!rawCart.email && data.email) {
-          console.log("prepping to call createOrFetchGuestCustomerFromEmailAndSalesChannel_...")
+          console.log("prepping to call createOrFetchGuestCustomerFromEmailAndSalesChannel_ from cart create function...")
           console.log(data.email, data.sales_channel_id)
           const customer = await this.createOrFetchGuestCustomerFromEmailAndSalesChannel_(
             data.email, data.sales_channel_id
@@ -216,6 +222,184 @@ class CartService extends MedusaCartService {
             id: cart.id,
           })
         return cart
+      }
+    )
+  }
+
+  async update(cartId: string, data: CartUpdateProps): Promise<Cart> {
+    return await this.atomicPhase_(
+      async (transactionManager: EntityManager) => {
+        console.log("starting update cart function")
+        const cartRepo = transactionManager.withRepository(this.cartRepository_)
+        const relations = [
+          "items",
+          "items.variant",
+          "items.variant.product",
+          "shipping_methods",
+          "shipping_methods.shipping_option",
+          "shipping_address",
+          "billing_address",
+          "gift_cards",
+          "customer",
+          "region",
+          "payment_sessions",
+          "region.countries",
+          "discounts",
+          "discounts.rule",
+        ]
+
+        if (
+          this.featureFlagRouter_.isFeatureEnabled(
+            SalesChannelFeatureFlag.key
+          ) &&
+          data.sales_channel_id
+        ) {
+          relations.push("items.variant", "items.variant.product")
+        }
+
+        console.log("data during update", data)
+
+        const cart = await this.retrieve(cartId, {
+          relations,
+        })
+        console.log("cart before customer is created:")
+        console.log(cart)
+
+        const originalCartCustomer = { ...(cart.customer ?? {}) }
+        if (data.customer_id) {
+          await this.updateCustomerId_(cart, data.customer_id)
+        } else if (isDefined(data.email)) {
+          console.log("prepping to call createOrFetchGuestCustomerFromEmailAndSalesChannel_ from cart update function...")
+          console.log(data.email, cart.sales_channel_id)
+          const customer = await this.createOrFetchGuestCustomerFromEmailAndSalesChannel_(
+            data.email, cart.sales_channel_id
+          )
+          cart.customer = customer
+          cart.customer_id = customer.id
+          cart.email = customer.email
+        }
+        console.log("cart after customer is created:")
+        console.log(cart)
+
+
+        if (isDefined(data.customer_id) || isDefined(data.region_id)) {
+          await this.updateUnitPrices_(cart, data.region_id, data.customer_id)
+        }
+
+        if (isDefined(data.region_id)) {
+          const shippingAddress =
+            typeof data.shipping_address !== "string"
+              ? data.shipping_address
+              : {}
+          const countryCode =
+            (data.country_code || shippingAddress?.country_code) ?? null
+          await this.setRegion_(cart, data.region_id, countryCode)
+        }
+
+        const addrRepo = transactionManager.withRepository(
+          this.addressRepository_
+        )
+
+        const billingAddress = data.billing_address_id ?? data.billing_address
+        if (billingAddress !== undefined) {
+          await this.updateBillingAddress_(cart, billingAddress, addrRepo)
+        }
+
+        const shippingAddress =
+          data.shipping_address_id ?? data.shipping_address
+        if (shippingAddress !== undefined) {
+          await this.updateShippingAddress_(cart, shippingAddress, addrRepo)
+        }
+
+        if (
+          this.featureFlagRouter_.isFeatureEnabled(
+            SalesChannelFeatureFlag.key
+          ) &&
+          isDefined(data.sales_channel_id) &&
+          data.sales_channel_id != cart.sales_channel_id
+        ) {
+          await this.onSalesChannelChange(cart, data.sales_channel_id)
+          cart.sales_channel_id = data.sales_channel_id
+        }
+
+        if (isDefined(data.discounts) && data.discounts.length) {
+          const previousDiscounts = [...cart.discounts]
+          cart.discounts.length = 0
+
+          await this.applyDiscounts(
+            cart,
+            data.discounts.map((d) => d.code)
+          )
+
+          const hasFreeShipping = cart.discounts.some(
+            ({ rule }) => rule?.type === DiscountRuleType.FREE_SHIPPING
+          )
+
+          // if we previously had a free shipping discount and then removed it,
+          // we need to update shipping methods to original price
+          if (
+            previousDiscounts.some(
+              ({ rule }) => rule.type === DiscountRuleType.FREE_SHIPPING
+            ) &&
+            !hasFreeShipping
+          ) {
+            await this.adjustFreeShipping_(cart, false)
+          }
+
+          if (hasFreeShipping) {
+            await this.adjustFreeShipping_(cart, true)
+          }
+        } else if (isDefined(data.discounts) && !data.discounts.length) {
+          cart.discounts.length = 0
+          await this.refreshAdjustments_(cart)
+        }
+
+        if ("gift_cards" in data) {
+          cart.gift_cards = []
+
+          await Promise.all(
+            (data.gift_cards ?? []).map(async ({ code }) => {
+              return this.applyGiftCard_(cart, code)
+            })
+          )
+        }
+
+        if (data?.metadata) {
+          cart.metadata = setMetadata(cart, data.metadata)
+        }
+
+        if ("context" in data) {
+          const prevContext = cart.context || {}
+          cart.context = {
+            ...prevContext,
+            ...data.context,
+          }
+        }
+
+        if ("completed_at" in data) {
+          cart.completed_at = data.completed_at!
+        }
+
+        if ("payment_authorized_at" in data) {
+          cart.payment_authorized_at = data.payment_authorized_at!
+        }
+
+        const updatedCart = await cartRepo.save(cart)
+
+        if (
+          (data.email && data.email !== originalCartCustomer.email) ||
+          (data.customer_id && data.customer_id !== originalCartCustomer.id)
+        ) {
+          await this.eventBus_
+            .withTransaction(transactionManager)
+            .emit(CartService.Events.CUSTOMER_UPDATED, updatedCart.id)
+        }
+
+        await this.eventBus_
+          .withTransaction(transactionManager)
+          .emit(CartService.Events.UPDATED, updatedCart)
+
+        return updatedCart
       }
     )
   }

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -1,0 +1,224 @@
+import { Lifetime } from "awilix"
+import { Customer } from "../models/customer"
+import CustomerService from "../services/customer"
+import { validateEmail } from "@medusajs/medusa/dist/utils/is-email"
+import { CartService as MedusaCartService } from "@medusajs/medusa"
+// extra imports for create function
+import {
+  CartCreateProps,
+} from "@medusajs/medusa/dist/types/cart"
+import {
+  Cart,
+} from "@medusajs/medusa/dist/models"
+import { DeepPartial, EntityManager } from "typeorm"
+import SalesChannelFeatureFlag from "@medusajs/medusa/dist/loaders/feature-flags/sales-channels"
+import { isDefined, MedusaError } from "medusa-core-utils"
+
+type InjectedDependencies = {
+  customerService: CustomerService
+}
+
+class CartService extends MedusaCartService {
+  static LIFE_TIME = Lifetime.SCOPED
+  protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base CartService
+
+  constructor( dependencies: InjectedDependencies ) {
+    // @ts-expect-error prefer-rest-params
+    super(...arguments)
+    
+    try {
+      this.customerService_ = dependencies.customerService
+    } catch (e) {
+      // avoid errors when backend first runs
+    }
+  }
+
+  /**
+   * Creates or fetches a user based on an email.
+   * Extended from medusa core to retrieve customer
+   * matching the sales channel provided in the header.
+   * @param email - the email to use
+   * @return the resulting customer object
+   */
+  protected async createOrFetchGuestCustomerFromEmailAndSalesChannel_(
+    email: string,
+    sales_channel_id: string,
+  ): Promise<Customer> {
+    
+  	console.log("createOrFetchGuestCustomerFromEmail_ running...")
+  	console.log("email: ", email)
+  	console.log("sales channel id: ", sales_channel_id)
+  	
+    
+    const validatedEmail = validateEmail(email)
+    const salesChannelId = sales_channel_id
+
+    const customerServiceTx = this.customerService_.withTransaction(
+      this.activeManager_
+    )
+
+    let customer = await customerServiceTx
+      .retrieveUnregisteredByEmailAndSalesChannel(validatedEmail, salesChannelId)
+      .catch(() => undefined)
+
+    if (!customer) {
+      customer = await customerServiceTx.create({ email: validatedEmail })
+    }
+
+	/*console.log("Email:", email);
+	console.log("customerServiceTx:", customerServiceTx);
+	console.log("validatedEmail:", validatedEmail);
+	console.log("customer:", customer);*/
+
+    console.log("createOrFetchGuestCustomerFromEmail_ completed...")
+    return customer
+  }
+
+  /**
+   * Creates a cart.
+   * @param data - the data to create the cart with
+   * @return the result of the create operation
+   */
+  async create(data: CartCreateProps): Promise<Cart | never> {
+    return await this.atomicPhase_(
+      async (transactionManager: EntityManager) => {
+        console.log("create cart function starting...")
+        const cartRepo = transactionManager.withRepository(this.cartRepository_)
+        const addressRepo = transactionManager.withRepository(
+          this.addressRepository_
+        )
+
+        const rawCart: DeepPartial<Cart> = {
+          context: data.context ?? {},
+        }
+
+        if (
+          this.featureFlagRouter_.isFeatureEnabled(SalesChannelFeatureFlag.key)
+        ) {
+          rawCart.sales_channel_id = (
+            await this.getValidatedSalesChannel(data.sales_channel_id)
+          ).id
+        }
+
+        if (data.customer_id) {
+          const customer = await this.customerService_
+            .withTransaction(transactionManager)
+            .retrieve(data.customer_id)
+            .catch(() => undefined)
+          rawCart.customer = customer
+          rawCart.customer_id = customer?.id
+          rawCart.email = customer?.email
+        }
+
+        if (!rawCart.email && data.email) {
+          console.log("prepping to call createOrFetchGuestCustomerFromEmailAndSalesChannel_...")
+          console.log(data.email, data.sales_channel_id)
+          const customer = await this.createOrFetchGuestCustomerFromEmailAndSalesChannel_(
+            data.email, data.sales_channel_id
+          )
+          rawCart.customer = customer
+          rawCart.customer_id = customer.id
+          rawCart.email = customer.email
+        }
+
+        if (!data.region_id && !data.region) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `A region_id must be provided when creating a cart`
+          )
+        }
+
+        rawCart.region_id = data.region_id
+        const region = data.region
+          ? data.region
+          : await this.regionService_
+              .withTransaction(transactionManager)
+              .retrieve(data.region_id!, {
+                relations: ["countries"],
+              })
+        const regCountries = region.countries.map(({ iso_2 }) => iso_2)
+
+        if (!data.shipping_address && !data.shipping_address_id) {
+          if (region.countries.length === 1) {
+            rawCart.shipping_address = addressRepo.create({
+              country_code: regCountries[0],
+            })
+          }
+        } else {
+          if (data.shipping_address) {
+            if (!regCountries.includes(data.shipping_address.country_code!)) {
+              throw new MedusaError(
+                MedusaError.Types.NOT_ALLOWED,
+                "Shipping country not in region"
+              )
+            }
+            rawCart.shipping_address = data.shipping_address
+          }
+          if (data.shipping_address_id) {
+            const addr = await addressRepo.findOne({
+              where: { id: data.shipping_address_id },
+            })
+            if (
+              addr?.country_code &&
+              !regCountries.includes(addr.country_code)
+            ) {
+              throw new MedusaError(
+                MedusaError.Types.NOT_ALLOWED,
+                "Shipping country not in region"
+              )
+            }
+            rawCart.shipping_address_id = data.shipping_address_id
+          }
+        }
+
+        if (data.billing_address) {
+          if (!regCountries.includes(data.billing_address.country_code!)) {
+            throw new MedusaError(
+              MedusaError.Types.NOT_ALLOWED,
+              "Billing country not in region"
+            )
+          }
+          rawCart.billing_address = data.billing_address
+        }
+        if (data.billing_address_id) {
+          const addr = await addressRepo.findOne({
+            where: { id: data.billing_address_id },
+          })
+          if (addr?.country_code && !regCountries.includes(addr.country_code)) {
+            throw new MedusaError(
+              MedusaError.Types.NOT_ALLOWED,
+              "Billing country not in region"
+            )
+          }
+          rawCart.billing_address_id = data.billing_address_id
+        }
+
+        const remainingFields: (keyof Cart)[] = [
+          "context",
+          "type",
+          "metadata",
+          "discounts",
+          "gift_cards",
+        ]
+
+        for (const remainingField of remainingFields) {
+          if (isDefined(data[remainingField]) && remainingField !== "object") {
+            const key = remainingField as string
+            rawCart[key] = data[remainingField]
+          }
+        }
+
+        const createdCart = cartRepo.create(rawCart)
+        const cart = await cartRepo.save(createdCart)
+        await this.eventBus_
+          .withTransaction(transactionManager)
+          .emit(CartService.Events.CREATED, {
+            id: cart.id,
+          })
+        return cart
+      }
+    )
+  }
+}
+
+export default CartService

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -56,6 +56,19 @@ class CustomerService extends MedusaCustomerService {
     return customer
   }
 
+  async retrieveUnregisteredByEmailAndSalesChannel(
+    email: string,
+    sales_channel_id: string,
+    config: FindConfig<Customer> = {}
+  ): Promise<Customer | never> {
+    console.log("retrieveUnregisteredByEmailAndSalesChannel running...")
+    console.log("sales_channel_id: ", sales_channel_id)
+    return await this.retrieveBySalesChannel_(
+      { email: email.toLowerCase(), has_account: false, sales_channel_id: sales_channel_id },
+      config
+    )
+  }
+
   async retrieveRegisteredByEmailAndSalesChannel(
     email: string,
     config: FindConfig<Customer> = {}
@@ -128,6 +141,8 @@ class CustomerService extends MedusaCustomerService {
         customer.has_account = true
         delete customer.password
       }
+
+      console.log("Creating customer with props: ", customer.email, customer.has_account, customer.sales_channel_id)
 
       const created = customerRepository.create(customer)
       const result = await customerRepository.save(created)

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -5,6 +5,7 @@ import { CustomerService as MedusaCustomerService } from "@medusajs/medusa"
 import { Customer } from "../models/customer"
 import { buildQuery } from "@medusajs/medusa/dist/utils"
 import { CreateCustomerInput as MedusaCreateCustomerInput } from "@medusajs/medusa/dist/types/customers"
+import { debugLog } from "../scripts/debug"
 
 type CreateCustomerInput = {
   sales_channel_id?: string;
@@ -61,8 +62,8 @@ class CustomerService extends MedusaCustomerService {
     sales_channel_id: string,
     config: FindConfig<Customer> = {}
   ): Promise<Customer | never> {
-    console.log("retrieveUnregisteredByEmailAndSalesChannel running...")
-    console.log("sales_channel_id: ", sales_channel_id)
+    debugLog("retrieveUnregisteredByEmailAndSalesChannel running...")
+    debugLog("email:", email, "sales channel id:", sales_channel_id)
     return await this.retrieveBySalesChannel_(
       { email: email.toLowerCase(), has_account: false, sales_channel_id: sales_channel_id },
       config
@@ -73,6 +74,8 @@ class CustomerService extends MedusaCustomerService {
     email: string,
     config: FindConfig<Customer> = {}
   ): Promise<Customer | never> {
+    debugLog("retrieveRegisteredByEmailAndSalesChannel running...")
+    debugLog("email:", email, "sales channel id:", this.salesChannel_)
     return await this.retrieveBySalesChannel_(
       { email: email.toLowerCase(), has_account: true, sales_channel_id: this.salesChannel_ },
       config
@@ -84,6 +87,8 @@ class CustomerService extends MedusaCustomerService {
     salesChannelId: string,
     config: FindConfig<Customer> = { relations: [], skip: 0, take: 2 }
   ): Promise<Customer[]> {
+    debugLog("listByEmailAndSalesChannel running...")
+    debugLog("email:", email, "sales channel id:", salesChannelId)
     const filter: CustomerFilter = {
       email: email.toLowerCase(),
       sales_channel_id: salesChannelId,
@@ -103,8 +108,9 @@ class CustomerService extends MedusaCustomerService {
    * @param {object} customer - the customer to create
    * @return {Promise} the result of create
    */
-
   async create(customer: CreateCustomerInput): Promise<Customer> {
+    debugLog("customer.create running...")
+    debugLog("sales channel id:", this.salesChannel_)
     return await this.atomicPhase_(async (manager) => {
 
       const customerRepository = manager.withRepository(
@@ -142,7 +148,9 @@ class CustomerService extends MedusaCustomerService {
         delete customer.password
       }
 
-      console.log("Creating customer with props: ", customer.email, customer.has_account, customer.sales_channel_id)
+      //else (customer.has_account = false)
+
+      debugLog("calling customer.create with props:", "email:", customer.email, "has_account:", customer.has_account, "sales channel id:", customer.sales_channel_id)
 
       const created = customerRepository.create(customer)
       const result = await customerRepository.save(created)

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -10,10 +10,6 @@ type CreateCustomerInput = {
   sales_channel_id?: string;
 } & MedusaCreateCustomerInput;
 
-type CustomerSelector = MedusaSelector<Customer> & {
-  sales_channel_id?: string;
-};
-
 type CustomerFilter = {
   email: string;
   sales_channel_id?: string;

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -1,0 +1,113 @@
+import { Lifetime } from "awilix"
+import { MedusaError } from "medusa-core-utils"
+import { FindConfig, Selector as MedusaSelector } from "@medusajs/medusa/dist/types/common"
+import { CustomerService as MedusaCustomerService } from "@medusajs/medusa"
+import { Customer } from "../models/customer"
+import { CreateCustomerInput as MedusaCreateCustomerInput } from "@medusajs/medusa/dist/types/customers"
+
+type CreateCustomerInput = {
+  sales_channel_id?: string;
+} & MedusaCreateCustomerInput;
+
+type CustomerSelector = MedusaSelector<Customer> & {
+  sales_channel_id?: string;
+};
+
+type CustomerFilter = {
+  email: string;
+  sales_channel_id?: string;
+};
+
+class CustomerService extends MedusaCustomerService {
+  static LIFE_TIME = Lifetime.SCOPED
+
+  // initialise Sales Channel
+  protected readonly salesChannel_: string | null = null;
+
+  // capture Sales Channel from middleware
+  constructor(container, options) {
+    // @ts-expect-error prefer-rest-params
+    super(...arguments)
+    
+    try {
+      this.salesChannel_ = container.salesChannel
+    } catch (e) {
+      // avoid errors when backend first runs
+    }
+  }
+
+  async listByEmailAndSalesChannel(
+    email: string,
+    salesChannelId: string,
+    config: FindConfig<Customer> = { relations: [], skip: 0, take: 2 }
+  ): Promise<Customer[]> {
+    const filter: CustomerFilter = {
+      email: email.toLowerCase(),
+      sales_channel_id: salesChannelId,
+    };
+
+    const existing = await this.list(filter, config).catch(() => undefined);
+    return existing || [];
+  }
+
+  /**
+   * Creates a customer from an email - customers can have accounts associated,
+   * e.g. to login and view order history, etc. If a password is provided the
+   * customer will automatically get an account, otherwise the customer is just
+   * used to hold details of customers. Extended from medusa core to take sales
+   * channel from request header captured in middleware to allow one customer
+   * per email (regular and guest) per sales channel.
+   * @param {object} customer - the customer to create
+   * @return {Promise} the result of create
+   */
+
+  async create(customer: CreateCustomerInput): Promise<Customer> {
+    return await this.atomicPhase_(async (manager) => {
+
+      const customerRepository = manager.withRepository(
+        this.customerRepository_
+      )
+
+      customer.email = customer.email.toLowerCase()
+      customer.sales_channel_id = this.salesChannel_
+
+      const { email, password } = customer
+
+      // should be a list of customers at this point
+      const existing = await this.listByEmailAndSalesChannel(email, this.salesChannel_).catch(() => undefined)
+
+      // should validate that "existing.some(acc => acc.has_account) && password"
+      if (existing) {
+        if (existing.some((customer) => customer.has_account) && password) {
+          throw new MedusaError(
+            MedusaError.Types.DUPLICATE_ERROR,
+            "A customer with the given email already has an account. Log in instead"
+          )
+        } else if (
+          existing?.some((customer) => !customer.has_account) && !password) {
+          throw new MedusaError(
+            MedusaError.Types.DUPLICATE_ERROR,
+            "Guest customer with email already exists"
+          )
+        }
+      }
+
+      if (password) {
+        const hashedPassword = await this.hashPassword_(password)
+        customer.password_hash = hashedPassword
+        customer.has_account = true
+        delete customer.password
+      }
+
+      const created = customerRepository.create(customer)
+      const result = await customerRepository.save(created)
+      await this.eventBusService_
+        .withTransaction(manager)
+        .emit(CustomerService.Events.CREATED, result)
+
+      return result
+    })
+  }
+}
+
+export default CustomerService

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -112,7 +112,7 @@ class CustomerService extends MedusaCustomerService {
       )
 
       customer.email = customer.email.toLowerCase()
-      customer.sales_channel_id = this.salesChannel_
+      if (!customer.sales_channel_id) { customer.sales_channel_id = this.salesChannel_ }
 
       const { email, password } = customer
 

--- a/src/subscribers/customer-confirmation.ts
+++ b/src/subscribers/customer-confirmation.ts
@@ -26,20 +26,22 @@ class CustomerConfirmationSubscriber {
   }
 
   handleCustomerConfirmation = async (data: Customer) => {
-    this.sendGridService.sendEmail({
-      templateId: SENDGRID_CUSTOMER_CONFIRMATION,
-      from: SENDGRID_FROM,
-      to: data.email,
-      dynamic_template_data: {
-        email: data.email,
-        first_name: data.first_name,
-        last_name: data.last_name,
-        store_url: STORE_URL,
-        store_name: STORE_NAME,
-        store_logo: STORE_LOGO
-        /*data*/ /* add in to see the full data object returned by the event */
-      },
-    })
+    if (data.has_account) (
+      this.sendGridService.sendEmail({
+        templateId: SENDGRID_CUSTOMER_CONFIRMATION,
+        from: SENDGRID_FROM,
+        to: data.email,
+        dynamic_template_data: {
+          email: data.email,
+          first_name: data.first_name,
+          last_name: data.last_name,
+          store_url: STORE_URL,
+          store_name: STORE_NAME,
+          store_logo: STORE_LOGO
+          /*data*/ /* add in to see the full data object returned by the event */
+        },
+      })
+    )
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,11 +2247,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medusajs/medusa-cli@npm:1.3.14":
-  version: 1.3.14
-  resolution: "@medusajs/medusa-cli@npm:1.3.14"
+"@medusajs/medusa-cli@npm:1.3.15":
+  version: 1.3.15
+  resolution: "@medusajs/medusa-cli@npm:1.3.15"
   dependencies:
-    "@medusajs/utils": 1.8.5
+    "@medusajs/utils": 1.9.0
     axios: ^0.21.4
     chalk: ^4.0.0
     configstore: 5.0.1
@@ -2273,7 +2273,6 @@ __metadata:
     regenerator-runtime: ^0.13.11
     resolve-cwd: ^3.0.0
     semver: ^7.3.8
-    sqlite3: ^5.0.2
     stack-trace: ^0.0.10
     ulid: ^2.3.0
     url: ^0.11.0
@@ -2281,7 +2280,7 @@ __metadata:
     yargs: ^15.3.1
   bin:
     medusa: cli.js
-  checksum: 3905c63fe58fd429ca679e7b1c246e7f3ca6c19a1e561e84946de1ac2e646c19135e5aba88a106c15a52c781f181fb97c3f6b1356c17e8ee814c19e5d880acb7
+  checksum: 293be434863c5d9a667e8c18498292fe1afcb63d05dd17b088980f6574b92005e07c12c06e2e380f9584894ff8aba5258635a1aa2f5e71c5f829174f367fc86b
   languageName: node
   linkType: hard
 
@@ -2337,13 +2336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medusajs/medusa@npm:1.11.0":
-  version: 1.11.0
-  resolution: "@medusajs/medusa@npm:1.11.0"
+"@medusajs/medusa@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@medusajs/medusa@npm:1.12.0"
   dependencies:
-    "@medusajs/medusa-cli": 1.3.14
-    "@medusajs/modules-sdk": 1.8.6
-    "@medusajs/utils": 1.8.5
+    "@medusajs/medusa-cli": 1.3.15
+    "@medusajs/modules-sdk": 1.8.7
+    "@medusajs/utils": 1.9.0
     "@types/ioredis": ^4.28.10
     "@types/lodash": ^4.14.191
     awilix: ^8.0.0
@@ -2375,7 +2374,7 @@ __metadata:
     morgan: ^1.9.1
     multer: ^1.4.5-lts.1
     node-schedule: ^2.1.1
-    papaparse: ^5.3.2
+    papaparse: 5.3.2
     passport: ^0.6.0
     passport-http-bearer: ^1.0.1
     passport-jwt: ^4.0.1
@@ -2390,12 +2389,12 @@ __metadata:
     uuid: ^9.0.0
     winston: ^3.8.2
   peerDependencies:
-    "@medusajs/types": 1.8.6
+    "@medusajs/types": 1.8.7
     medusa-interfaces: 1.3.7
     typeorm: "*"
   bin:
     medusa: cli.js
-  checksum: 1f76f8f832963539355f02d8f68c61df7f8d0685955fffa002d773e3ff511712c4610eea4215ac686850335d75af82ca38ae47072216293b69d0c8c8f53d9c5b
+  checksum: 3958444b385f128c77bbba8b067bc7fb89dc8aa9026e4aa95c83a240806dfe0b72d339fa2be7af74074f595e984423df11b9bce0ba6031608c98dcb1f468db14
   languageName: node
   linkType: hard
 
@@ -2413,17 +2412,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medusajs/modules-sdk@npm:1.8.6":
-  version: 1.8.6
-  resolution: "@medusajs/modules-sdk@npm:1.8.6"
+"@medusajs/modules-sdk@npm:1.8.7":
+  version: 1.8.7
+  resolution: "@medusajs/modules-sdk@npm:1.8.7"
   dependencies:
-    "@medusajs/types": 1.8.6
-    "@medusajs/utils": 1.8.5
+    "@medusajs/types": 1.8.7
+    "@medusajs/utils": 1.9.0
     awilix: ^8.0.0
     glob: 7.1.6
     medusa-telemetry: ^0.0.16
     resolve-cwd: ^3.0.0
-  checksum: 9934e5e6a7a7721c14b7ba0a93a92166dcbf15d35754ac9be07ed219608f05809e30df355ce1f6d50391f91670ab7f5e1a98e00cf19adc3d92a150c9d9057ccb
+  checksum: 3ce9313d6e58d56730f27f80a2548c72484aea97d0b2bca471f24e67d44ef3f0b14849329cc2db68e7667b007b39f2a56b77b40ebe76cde13588fa322c6a031f
   languageName: node
   linkType: hard
 
@@ -2434,10 +2433,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medusajs/types@npm:1.8.6":
-  version: 1.8.6
-  resolution: "@medusajs/types@npm:1.8.6"
-  checksum: a86553cb8807405478b5cf5ead1a1276b4b287893d05adf5d2f6695be12bcbbeb79f0d4c77cfe9f4d5d40e4ce5c5621da407f53145548c6720748feb9c5c2359
+"@medusajs/types@npm:1.8.7":
+  version: 1.8.7
+  resolution: "@medusajs/types@npm:1.8.7"
+  checksum: ff8201f0987e466ee29204e1f910a2c577f417f1223b645518d38e9dc4121acb48fa0365ed0a5c720975fbc824161c9d6844f2c9dad56603f516479ef4e2d983
   languageName: node
   linkType: hard
 
@@ -2454,16 +2453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medusajs/utils@npm:1.8.5":
-  version: 1.8.5
-  resolution: "@medusajs/utils@npm:1.8.5"
+"@medusajs/utils@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@medusajs/utils@npm:1.9.0"
   dependencies:
     awilix: ^8.0.0
-    class-transformer: ^0.5.1
-    class-validator: ^0.14.0
-    typeorm: ^0.3.16
     ulid: ^2.3.0
-  checksum: 568a82fbc146da1fed6dd66707c3f425053bad30b367995eeb027bc5492fe1aa6c9f33576e77bb8ba31eea4d425cb36d4c023ddb469a9d703cc8ee3650208a9d
+  checksum: c82a0a0b09767f81dd8112c5b3d1a40fc45154c03ee38fe1dfdac46a828d594c4fd6a5a7d479f88cd979c51640cf8fbf02647f452fa31cffb7dcca243768b7da
   languageName: node
   linkType: hard
 
@@ -9898,7 +9894,7 @@ __metadata:
     "@medusajs/cache-redis": ^1.8.4
     "@medusajs/event-bus-local": ^1.9.1
     "@medusajs/event-bus-redis": ^1.8.4
-    "@medusajs/medusa": 1.11.0
+    "@medusajs/medusa": 1.12.0
     "@medusajs/medusa-cli": ^1.3.12
     "@types/express": ^4.17.13
     "@types/jest": ^27.4.0
@@ -10860,10 +10856,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"papaparse@npm:^5.3.2":
-  version: 5.4.1
-  resolution: "papaparse@npm:5.4.1"
-  checksum: fc9e52f7158dca3517c229e3309065b1ab5da6c7194572fba4f31ff138bc43e3c91182cc40365cc828f97fe10d0aca416068fd731661058bea0f69ddb84a411a
+"papaparse@npm:5.3.2":
+  version: 5.3.2
+  resolution: "papaparse@npm:5.3.2"
+  checksum: a5950ef931a42f6759a8d3823a43dd30f375b37a0ddea6ea5448c0c5024cd226819231958c49c24fbcdeab297c63fd1d630130b3439876ea0fd17d8a267738ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**General additions**
* Updates to Medusa 1.12 from 1.11
* Add debugLog function for easy toggle of console.log messages using environment variable

**Multi-Site Functionality**

Want to use the sales channel concept to allow for multiple exclusive stores to be operated from a single medusa backend.

- **Customer Changes**
	+ Registered Customer Changes
		* Extend Customer to have a single Sales Channel ID (to use as unique stores)
			- Model (add SalesChannel column)
			- Repository (use extended model)
			- Migration (add column to database)
		* Extend Middleware and Routes
			- Middleware (to get saleschannel from storefront)
			- Routes to expose middleware
		* Extend Customer Service for Registration / Account Creation
			- initialise and construct
			- extend types (CreateCustomerInput, CustomerFilter)
			- extend helper functions (listByEmailAndSalesChannel)
			- extend create function
		* Extend Customer Service for Login / Authentication
			- extend helper functions (retrieveBySalesChannel_, retrieveRegisteredByEmailAndSalesChannel)
		* Extend Auth Service for Login / Authentication
			- inject dependencies
			- initialise and construct
			- extend authenticateCustomer function
	+ Guest Customer Changes
		* assign Sales Channel ID to new Guest Customer Accounts
		* extend create and update functions
		* stop emails generating with customer.created for guest accounts
- **Cart Changes**
	+ pass Sales Channel ID to new Carts as an argument
	+ see https://docs.medusajs.com/modules/sales-channels/storefront/use-sales-channels#when-creating-a-cart
- **Orders**
	+ pass Sales Channel ID to new Orders as an argument
	+ see https://docs.medusajs.com/modules/sales-channels

- **Storefront Changes** (see https://github.com/devonsydney/medusa-storefront/pull/2 for details)
	+ Register component
		* src/modules/account/components/register
	+ Login component
		* src/modules/account/components/login
	+ On query for products, filter by Sales Channel ID from the environment variable
	+ On query for collections, filter out empty
	+ Only build products in the Sales Channel
	+ Only build collections in the Sales Channel
- **Admin Frontend Changes** (wait for admin extensibility to be released, this should be easy)
	+ Add 'Sales Channel ID' column to customer list

This feature is reasonably complete, what is required is some more robust e2e testing.