### PR TITLE
Feature move storefront variables

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,5 @@
+export declare module "@medusajs/medusa/dist/models/customer" {
+  declare interface Customer {
+    sales_channel_id?: string;
+  }
+}

--- a/src/scripts/sales-channel.ts
+++ b/src/scripts/sales-channel.ts
@@ -1,0 +1,7 @@
+export const getStoreDetails = (sales_channel) => {
+    return {
+        store_name: sales_channel.name,
+        store_url: sales_channel.description,
+        // add any other details as needed in future
+    };
+}

--- a/src/subscribers/customer-confirmation.ts
+++ b/src/subscribers/customer-confirmation.ts
@@ -1,25 +1,31 @@
-import { Customer, EventBusService } from "@medusajs/medusa"
+import { CustomerService, SalesChannelService, EventBusService } from "@medusajs/medusa"
 import { getProfileByEmail, createProfile } from "../scripts/klaviyo"
+import { getStoreDetails } from "../scripts/sales-channel";
 import { debugLog } from "../scripts/debug"
 
 const SENDGRID_CUSTOMER_CONFIRMATION = process.env.SENDGRID_CUSTOMER_CONFIRMATION
 const SENDGRID_FROM = process.env.SENDGRID_FROM
-const STORE_URL = process.env.STORE_URL
-const STORE_NAME = process.env.STORE_NAME
-const STORE_LOGO = process.env.STORE_LOGO
 
 type InjectedDependencies = {
   eventBusService: EventBusService,
+  customerService: CustomerService,
+  salesChannelService: SalesChannelService,
   sendgridService: any
 }
 
 class CustomerConfirmationSubscriber {
+  protected readonly customerService_: CustomerService
+  protected readonly salesChannelService_: SalesChannelService
   protected sendGridService: any
 
   constructor({
     eventBusService,
+    customerService,
+    salesChannelService,
     sendgridService,
   }: InjectedDependencies) {
+    this.customerService_ = customerService
+    this.salesChannelService_ = salesChannelService
     this.sendGridService = sendgridService
     eventBusService.subscribe(
       "customer.created", 
@@ -27,55 +33,62 @@ class CustomerConfirmationSubscriber {
     )
   }
 
-  handleCustomerConfirmation = async (data: Customer) => {
+  handleCustomerConfirmation = async (data: Record<string, any>) => {
+    const customer = await this.customerService_.retrieve(data.id)
+    const sales_channel = await this.salesChannelService_.retrieve(data.sales_channel_id)
+    const { store_name, store_url } = getStoreDetails(sales_channel);
+
     debugLog("handleCustomerConfirmation running...")
-    if (data.has_account) {
+    if (customer.has_account) {
       debugLog("customer has account...")
-      this.sendgridEmail(data)
-      this.klaviyoCreateProfile(data)
+      this.sendgridEmail(customer, store_name, store_url)
+      this.klaviyoCreateProfile(customer, store_name, store_url)
     }
   }
 
   // SendGrid Email Handler
-  sendgridEmail = (data: any) => {
-    debugLog("sending email to:", data.email)
+  sendgridEmail = (customer: any, store_name, store_url) => {
+    debugLog("sending email to:", customer.email)
     debugLog("using template ID:", SENDGRID_CUSTOMER_CONFIRMATION)
-    debugLog("using STORE_URL value:", STORE_URL)
+    debugLog("using store_name:", store_name)
+    debugLog("using store_url:", store_url)
     
     this.sendGridService.sendEmail({
       templateId: SENDGRID_CUSTOMER_CONFIRMATION,
       from: SENDGRID_FROM,
-      to: data.email,
+      to: customer.email,
       dynamic_template_data: {
-        email: data.email,
-        first_name: data.first_name,
-        last_name: data.last_name,
-        store_url: STORE_URL,
-        store_name: STORE_NAME,
-        store_logo: STORE_LOGO
+        email: customer.email,
+        first_name: customer.first_name,
+        last_name: customer.last_name,
+        store_name: store_name,
+        store_url: store_url,
+        store_logo: store_url + "/favicon.ico",
         /*data*/ /* add in to see the full data object returned by the event */
       },
     })    
   }
 
   // Klaviyo Profile Handler
-  klaviyoCreateProfile = async (data: any) => {
+  klaviyoCreateProfile = async (customer: any, store_name, store_url) => {
     // Check if profile exists
     debugLog("Check if profile exists in Klaviyo...")
-    const profiles = await getProfileByEmail(data.email)
+    const profiles = await getProfileByEmail(customer.email)
+    debugLog("Profiles returned:", profiles)
     debugLog("Profiles returned (0 or 1):", profiles.data.length)
 
     // If profile does not exist, create it
     if (!profiles.data.length) {
       debugLog("Klaviyo profile does not exist, creating...")
       const newProfile = {
-        email: data.email,
-        first_name: data.first_name,
-        last_name: data.last_name,
-        phone_number: data.phone,
+        email: customer.email,
+        first_name: customer.first_name,
+        last_name: customer.last_name,
+        // phone_number: customer.phone,
         // Add more attributes if needed
         properties: {
-          store_name: STORE_NAME
+          store_name: store_name,
+          store_url: store_url,
         }
       }
       const createdProfile = await createProfile(newProfile)

--- a/src/subscribers/customer-password-reset.ts
+++ b/src/subscribers/customer-password-reset.ts
@@ -1,24 +1,30 @@
-import { Customer, EventBusService } from "@medusajs/medusa"
+import { CustomerService, SalesChannelService, EventBusService } from "@medusajs/medusa"
+import { getStoreDetails } from "../scripts/sales-channel";
 import { debugLog } from "../scripts/debug"
 
 const SENDGRID_CUSTOMER_PASSWORD_RESET = process.env.SENDGRID_CUSTOMER_PASSWORD_RESET
 const SENDGRID_FROM = process.env.SENDGRID_FROM
-const STORE_URL = process.env.STORE_URL
-const STORE_NAME = process.env.STORE_NAME
-const STORE_LOGO = process.env.STORE_LOGO
 
 type InjectedDependencies = {
   eventBusService: EventBusService,
+  customerService: CustomerService,
+  salesChannelService: SalesChannelService,
   sendgridService: any
 }
 
 class CustomerPasswordResetSubscriber {
+  protected readonly customerService_: CustomerService
+  protected readonly salesChannelService_: SalesChannelService
   protected sendGridService: any
 
   constructor({
     eventBusService,
+    customerService,
+    salesChannelService,
     sendgridService,
   }: InjectedDependencies) {
+    this.customerService_ = customerService
+    this.salesChannelService_ = salesChannelService
     this.sendGridService = sendgridService
     eventBusService.subscribe(
       "customer.password_reset", 
@@ -27,9 +33,15 @@ class CustomerPasswordResetSubscriber {
   }
 
   handleCustomerPasswordReset = async (data: Record<string, any>) => {
+    const customer = await this.customerService_.retrieve(data.id)
+    const sales_channel = await this.salesChannelService_.retrieve(customer.sales_channel_id)
+    debugLog("sales_channel:", sales_channel)
+    const { store_name, store_url } = getStoreDetails(sales_channel);
+
     debugLog("handleCustomerPasswordReset running...")
     debugLog("using template ID:", SENDGRID_CUSTOMER_PASSWORD_RESET)
-    debugLog("using STORE_URL value:", STORE_URL)
+    debugLog("using store_name:", store_name)
+    debugLog("using store_url:", store_url)
     debugLog("sending email to:", data.email)
     this.sendGridService.sendEmail({
       templateId: SENDGRID_CUSTOMER_PASSWORD_RESET,
@@ -40,9 +52,9 @@ class CustomerPasswordResetSubscriber {
         first_name: data.first_name,
         last_name: data.last_name,
         token: data.token,
-        store_url: STORE_URL,
-        store_name: STORE_NAME,
-        store_logo: STORE_LOGO
+        store_name: store_name,
+        store_url: store_url,
+        store_logo: store_url + "/favicon.ico",
         /*data*/ /* add in to see the full data object returned by the event */
       },
     })


### PR DESCRIPTION
This was to eliminate the incorrectly placed storefront details that were previously stored in the backend .env which would have made it impossible to run multiple storefronts. Now they are stored in the backend database so can be managed there.

Also added proper typing for the Customer entity which was missing.