### PR TITLE
Refactor services for dealing with multi-site

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,10 @@
 import { Router } from "express"
-import { registerSalesChannel } from "./middlewares/sales-channel"
+import { registerSalesChannelID } from "./middlewares/sales-channel"
 
 export default (rootDirectory: string): Router | Router[] => {
   // Custom routes
   const router = Router()
-  router.use(registerSalesChannel)
+  router.use(registerSalesChannelID)
 
   return router
 }

--- a/src/api/middlewares/sales-channel.ts
+++ b/src/api/middlewares/sales-channel.ts
@@ -1,13 +1,21 @@
 import { Lifetime } from "awilix"
+import PublishableApiKeyService from "@medusajs/medusa/dist/services/publishable-api-key"
+import { NextFunction, Request, Response } from "express"
 
 export async function registerSalesChannel(req, res, next) {
-  // Retrieve Sales Channel from the request header 
-  const salesChannel = req.header("sales_channel_id")
+  // resolve publishable key service
+  const publishableKeyService: PublishableApiKeyService = req.scope.resolve("publishableApiKeyService")
+  // Retrieve x-publishable-api-key
+  const pubKey = req.get("x-publishable-api-key")
+  // grab sales channels
+  const channels = await publishableKeyService.listSalesChannels(pubKey)
+  // return key of first sales channel
+  const sales_channel_id = String(channels[0]?.id)
   
-  // Register the Sales Channel
+  // Register the Sales Channel ID
   req.scope.register({
     salesChannel: {
-      resolve: () => salesChannel,
+      resolve: () => sales_channel_id,
     },
   })
   

--- a/src/api/middlewares/sales-channel.ts
+++ b/src/api/middlewares/sales-channel.ts
@@ -1,8 +1,9 @@
 import { Lifetime } from "awilix"
 import PublishableApiKeyService from "@medusajs/medusa/dist/services/publishable-api-key"
 import { NextFunction, Request, Response } from "express"
+import { debugLog } from "../../scripts/debug";
 
-export async function registerSalesChannel(req, res, next) {
+export async function registerSalesChannelID(req, res, next) {
   // resolve publishable key service
   const publishableKeyService: PublishableApiKeyService = req.scope.resolve("publishableApiKeyService")
   // Retrieve x-publishable-api-key
@@ -11,10 +12,10 @@ export async function registerSalesChannel(req, res, next) {
   const channels = await publishableKeyService.listSalesChannels(pubKey)
   // return key of first sales channel
   const sales_channel_id = String(channels[0]?.id)
-  
+
   // Register the Sales Channel ID
   req.scope.register({
-    salesChannel: {
+    salesChannelID: {
       resolve: () => sales_channel_id,
     },
   })

--- a/src/models/customer.ts
+++ b/src/models/customer.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm"
 import { Customer as MedusaCustomer } from "@medusajs/medusa"
-import { SalesChannel } from "@medusajs/medusa"
 
 @Entity()
 export class Customer extends MedusaCustomer {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -39,7 +39,7 @@ class AuthService extends MedusaAuthService {
     debugLog("email:", email, "password:", password)
     debugLog("sales channel ID registered through middleware", this.salesChannelID_);
     
-    // make sure customer service is initialised (this will have been pulled from the AuthService parent constructor)
+    // customer service was initialised from the AuthService parent constructor
     if (!this.customerService_) {
       throw new Error("CustomerService is not initialized");
     }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,29 +1,20 @@
-import { Lifetime } from "awilix";
-import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth";
-import { Customer } from "../models/customer";
-import CustomerService from "../services/customer";
-import { AuthService as MedusaAuthService } from "@medusajs/medusa";
-import { debugLog } from "../scripts/debug";
-
-type InjectedDependencies = {
-  customerService: CustomerService;
-};
+import { Lifetime } from "awilix"
+import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth"
+import { AuthService as MedusaAuthService } from "@medusajs/medusa"
+import { Customer } from "@medusajs/medusa"
+import { debugLog } from "../scripts/debug"
 
 class AuthService extends MedusaAuthService {
-  static LIFE_TIME = Lifetime.SCOPED;
-  protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base AuthService
+  static LIFE_TIME = Lifetime.SCOPED
+  protected readonly salesChannelID_: string | null = null;
 
-  // initialise Sales Channel
-  protected readonly salesChannel_: string | null = null;
-
-  // capture Sales Channel from middleware
-  constructor(container, options, dependencies: InjectedDependencies) {
+  // constructor reads the salesChannelID from the container where it was registered by middleware
+  constructor( container ) {
     // @ts-expect-error prefer-rest-params
-    super(...arguments);
+    super(...arguments)
 
     try {
-      this.salesChannel_ = container.salesChannel;
-      this.customerService_ = dependencies.customerService;
+      this.salesChannelID_ = container.salesChannelID;
     } catch (e) {
       // avoid errors when backend first runs
     }
@@ -31,8 +22,8 @@ class AuthService extends MedusaAuthService {
 
   /**
    * Authenticates a customer based on an email, password combination. Uses
-   * scrypt to match password with hashed value. Extended from medusa core to
-   * retrieve customer matching the sales channel provided in the header.
+   * scrypt to match password with hashed value. Extended from medusa core to 
+   * retrieve customer matching the sales channel from middleware.
    * @param {string} email - the email of the user
    * @param {string} password - the password of the user
    * @return {{ success: (bool), customer: (object | undefined) }}
@@ -44,28 +35,36 @@ class AuthService extends MedusaAuthService {
     email: string,
     password: string
   ): Promise<AuthenticateResult> {
-    debugLog("authenticateCustomer running...");
-    debugLog("email:", email, "password:", password);
-    debugLog("sales channel registered through middleware", this.salesChannel_);
+    debugLog("authenticateCustomer running...")
+    debugLog("email:", email, "password:", password)
+    debugLog("sales channel ID registered through middleware", this.salesChannelID_);
+    
+    // make sure customer service is initialised (this will have been pulled from the AuthService parent constructor)
+    if (!this.customerService_) {
+      throw new Error("CustomerService is not initialized");
+    }
+
+    debugLog ("returning list of registered customers with entered email and expected sales channel ID")  
+    const customers = await this.customerService_.list({ email, has_account: true, sales_channel_id: this.salesChannelID_ })
+    debugLog ("customers:", customers)
+    const customer = customers.length > 0 ? customers[0] : null;
+    debugLog ("customer:", customer)
+
+    if (!customer) {
+      return {
+        success: false,
+        error: "Invalid email or password",
+      };
+    }
 
     return await this.atomicPhase_(async (transactionManager) => {
-      // get list of users with that email
-
       try {
-        const customerList: Customer[] = await this.customerService_
+        const customer: Customer = await this.customerService_
           .withTransaction(transactionManager)
-          .listByEmail(email.toLowerCase());
-        debugLog("customer list", customerList);
-
-        // get customer from customerList that has sales_channel matching this.salesChannel_
-        const customer = customerList.find(
-          (customer) => customer.sales_channel_id === this.salesChannel_
-        );
-        debugLog("selected customer", customer);
-        return;
-        // filter out sales channels
-
-        /*        if (customer.password_hash) {
+          .retrieveRegisteredByEmail(email, {
+            select: ["id", "password_hash"],
+          })
+        if (customer.password_hash) {
           const passwordsMatch = await this.comparePassword_(
             password,
             customer.password_hash
@@ -74,25 +73,24 @@ class AuthService extends MedusaAuthService {
           if (passwordsMatch) {
             const customer = await this.customerService_
               .withTransaction(transactionManager)
-              .retrieveRegisteredByEmailAndSalesChannel(email)
-            debugLog("authenticateCustomer success")
+              .retrieveRegisteredByEmail(email)
+
             return {
               success: true,
               customer,
             }
           }
-        }*/
+        }
       } catch (error) {
         // ignore
       }
 
-      debugLog("authenticateCustomer failed, invalid email or password");
       return {
         success: false,
         error: "Invalid email or password",
-      };
-    });
+      }
+    })
   }
 }
 
-export default AuthService;
+export default AuthService

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,16 +1,16 @@
-import { Lifetime } from "awilix"
-import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth"
-import { Customer } from "../models/customer"
-import CustomerService from "../services/customer"
-import { AuthService as MedusaAuthService } from "@medusajs/medusa"
-import { debugLog } from "../scripts/debug"
+import { Lifetime } from "awilix";
+import { AuthenticateResult } from "@medusajs/medusa/dist/types/auth";
+import { Customer } from "../models/customer";
+import CustomerService from "../services/customer";
+import { AuthService as MedusaAuthService } from "@medusajs/medusa";
+import { debugLog } from "../scripts/debug";
 
 type InjectedDependencies = {
-  customerService: CustomerService
-}
+  customerService: CustomerService;
+};
 
 class AuthService extends MedusaAuthService {
-  static LIFE_TIME = Lifetime.SCOPED
+  static LIFE_TIME = Lifetime.SCOPED;
   protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base AuthService
 
   // initialise Sales Channel
@@ -19,11 +19,11 @@ class AuthService extends MedusaAuthService {
   // capture Sales Channel from middleware
   constructor(container, options, dependencies: InjectedDependencies) {
     // @ts-expect-error prefer-rest-params
-    super(...arguments)
-    
+    super(...arguments);
+
     try {
-      this.salesChannel_ = container.salesChannel
-      this.customerService_ = dependencies.customerService
+      this.salesChannel_ = container.salesChannel;
+      this.customerService_ = dependencies.customerService;
     } catch (e) {
       // avoid errors when backend first runs
     }
@@ -31,7 +31,7 @@ class AuthService extends MedusaAuthService {
 
   /**
    * Authenticates a customer based on an email, password combination. Uses
-   * scrypt to match password with hashed value. Extended from medusa core to 
+   * scrypt to match password with hashed value. Extended from medusa core to
    * retrieve customer matching the sales channel provided in the header.
    * @param {string} email - the email of the user
    * @param {string} password - the password of the user
@@ -44,22 +44,28 @@ class AuthService extends MedusaAuthService {
     email: string,
     password: string
   ): Promise<AuthenticateResult> {
-    debugLog("authenticateCustomer running...")
-    debugLog("email:", email, "password:", password)
-    debugLog("sales channel registered through middleware", this.salesChannel_)
+    debugLog("authenticateCustomer running...");
+    debugLog("email:", email, "password:", password);
+    debugLog("sales channel registered through middleware", this.salesChannel_);
 
     return await this.atomicPhase_(async (transactionManager) => {
       // get list of users with that email
 
       try {
-        const customerList: [Customer] = await this.customerService_
+        const customerList: Customer[] = await this.customerService_
           .withTransaction(transactionManager)
-          .listByEmail( email.toLowerCase())
-        debugLog("customer list", customerList)
-        return
+          .listByEmail(email.toLowerCase());
+        debugLog("customer list", customerList);
+
+        // get customer from customerList that has sales_channel matching this.salesChannel_
+        const customer = customerList.find(
+          (customer) => customer.sales_channel_id === this.salesChannel_
+        );
+        debugLog("selected customer", customer);
+        return;
         // filter out sales channels
 
-/*        if (customer.password_hash) {
+        /*        if (customer.password_hash) {
           const passwordsMatch = await this.comparePassword_(
             password,
             customer.password_hash
@@ -80,13 +86,13 @@ class AuthService extends MedusaAuthService {
         // ignore
       }
 
-      debugLog("authenticateCustomer failed, invalid email or password")
+      debugLog("authenticateCustomer failed, invalid email or password");
       return {
         success: false,
         error: "Invalid email or password",
-      }
-    })
+      };
+    });
   }
 }
 
-export default AuthService
+export default AuthService;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -37,7 +37,7 @@ class AuthService extends MedusaAuthService {
   ): Promise<AuthenticateResult> {
     debugLog("authenticateCustomer running...")
     debugLog("email:", email, "password:", password)
-    debugLog("sales channel ID registered through middleware", this.salesChannelID_);
+    debugLog("sales channel ID registered through middleware:", this.salesChannelID_)
     
     // customer service was initialised from the AuthService parent constructor
     if (!this.customerService_) {

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -1,22 +1,6 @@
 import { Lifetime } from "awilix"
-import { Customer } from "../models/customer"
 import CustomerService from "../services/customer"
-import { validateEmail } from "@medusajs/medusa/dist/utils/is-email"
 import { CartService as MedusaCartService } from "@medusajs/medusa"
-// extra imports for create function
-import {
-  CartCreateProps,
-  CartUpdateProps
-} from "@medusajs/medusa/dist/types/cart"
-import {
-  Cart,
-  DiscountRuleType
-} from "@medusajs/medusa/dist/models"
-import { DeepPartial, EntityManager } from "typeorm"
-import SalesChannelFeatureFlag from "@medusajs/medusa/dist/loaders/feature-flags/sales-channels"
-import { isDefined, MedusaError } from "medusa-core-utils"
-import { setMetadata } from "@medusajs/medusa/dist/utils"
-import { debugLog } from "../scripts/debug"
 
 type InjectedDependencies = {
   customerService: CustomerService

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -1,0 +1,41 @@
+import { Lifetime } from "awilix"
+import { Customer } from "../models/customer"
+import CustomerService from "../services/customer"
+import { validateEmail } from "@medusajs/medusa/dist/utils/is-email"
+import { CartService as MedusaCartService } from "@medusajs/medusa"
+// extra imports for create function
+import {
+  CartCreateProps,
+  CartUpdateProps
+} from "@medusajs/medusa/dist/types/cart"
+import {
+  Cart,
+  DiscountRuleType
+} from "@medusajs/medusa/dist/models"
+import { DeepPartial, EntityManager } from "typeorm"
+import SalesChannelFeatureFlag from "@medusajs/medusa/dist/loaders/feature-flags/sales-channels"
+import { isDefined, MedusaError } from "medusa-core-utils"
+import { setMetadata } from "@medusajs/medusa/dist/utils"
+import { debugLog } from "../scripts/debug"
+
+type InjectedDependencies = {
+  customerService: CustomerService
+}
+
+class CartService extends MedusaCartService {
+  static LIFE_TIME = Lifetime.SCOPED
+  protected readonly customerService_: CustomerService = null!; // add initialiser to overwrite from base CartService
+
+  constructor( dependencies: InjectedDependencies ) {
+    // @ts-expect-error prefer-rest-params
+    super(...arguments)
+    
+    try {
+      this.customerService_ = dependencies.customerService
+    } catch (e) {
+      // avoid errors when backend first runs
+    }
+  }
+}
+
+export default CartService

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -20,7 +20,7 @@ class CustomerService extends MedusaCustomerService {
   static LIFE_TIME = Lifetime.SCOPED
 
   // initialise Sales Channel
-  protected readonly salesChannel_: string | null = null;
+  protected readonly salesChannelID_: string | null = null;
 
   // capture Sales Channel from middleware
   constructor(container, options) {
@@ -28,7 +28,7 @@ class CustomerService extends MedusaCustomerService {
     super(...arguments)
     
     try {
-      this.salesChannel_ = container.salesChannel
+      this.salesChannelID_ = container.salesChannelID
     } catch (e) {
       // avoid errors when backend first runs
     }
@@ -79,9 +79,9 @@ class CustomerService extends MedusaCustomerService {
   ): Promise<Customer | never> {
     debugLog("retrieveRegisteredByEmailAndSalesChannel running...")
     
-    debugLog("email:", email, "storefront sales channel id:", this.salesChannel_)
+    debugLog("email:", email, "storefront sales channel id:", this.salesChannelID_)
     return await this.retrieveBySalesChannel_(
-      { email: email.toLowerCase(), has_account: true, sales_channel_id: this.salesChannel_ },
+      { email: email.toLowerCase(), has_account: true, sales_channel_id: this.salesChannelID_ },
       config
     )
   }
@@ -114,7 +114,7 @@ class CustomerService extends MedusaCustomerService {
    */
   async create(customer: CreateCustomerInput): Promise<Customer> {
     debugLog("customer.create running...")
-    debugLog("sales channel id:", this.salesChannel_)
+    debugLog("sales channel id:", this.salesChannelID_)
     return await this.atomicPhase_(async (manager) => {
 
       const customerRepository = manager.withRepository(
@@ -122,12 +122,12 @@ class CustomerService extends MedusaCustomerService {
       )
 
       customer.email = customer.email.toLowerCase()
-      if (!customer.sales_channel_id) { customer.sales_channel_id = this.salesChannel_ }
+      if (!customer.sales_channel_id) { customer.sales_channel_id = this.salesChannelID_ }
 
       const { email, password } = customer
 
       // should be a list of customers at this point
-      const existing = await this.listByEmailAndSalesChannel(email, this.salesChannel_).catch(() => undefined)
+      const existing = await this.listByEmailAndSalesChannel(email, this.salesChannelID_).catch(() => undefined)
 
       // should validate that "existing.some(acc => acc.has_account) && password"
       if (existing) {

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -34,15 +34,18 @@ class CustomerService extends MedusaCustomerService {
     }
   }
 
-  private async retrieveBySalesChannel_(
+  public async retrieveBySalesChannel_(
     selector: MedusaSelector<Customer>,
     config: FindConfig<Customer> = {}
   ): Promise<Customer | never> {
+    debugLog("retrieveBySalesChannel running...")
     const customerRepo = this.activeManager_.withRepository(
       this.customerRepository_
     )
     const query = buildQuery(selector, config)
+    debugLog("query:", query)
     const customer = await customerRepo.findOne(query)
+    debugLog("customer retrieved:", customer)
 
     if (!customer) {
       const selectorConstraints = Object.entries(selector)
@@ -53,7 +56,7 @@ class CustomerService extends MedusaCustomerService {
         `Customer with ${selectorConstraints} was not found`
       )
     }
-
+    debugLog("retrieveBySalesChannel success...")
     return customer
   }
 
@@ -63,7 +66,7 @@ class CustomerService extends MedusaCustomerService {
     config: FindConfig<Customer> = {}
   ): Promise<Customer | never> {
     debugLog("retrieveUnregisteredByEmailAndSalesChannel running...")
-    debugLog("email:", email, "sales channel id:", sales_channel_id)
+    debugLog("email:", email, "storefront sales channel id:", sales_channel_id)
     return await this.retrieveBySalesChannel_(
       { email: email.toLowerCase(), has_account: false, sales_channel_id: sales_channel_id },
       config
@@ -75,7 +78,8 @@ class CustomerService extends MedusaCustomerService {
     config: FindConfig<Customer> = {}
   ): Promise<Customer | never> {
     debugLog("retrieveRegisteredByEmailAndSalesChannel running...")
-    debugLog("email:", email, "sales channel id:", this.salesChannel_)
+    
+    debugLog("email:", email, "storefront sales channel id:", this.salesChannel_)
     return await this.retrieveBySalesChannel_(
       { email: email.toLowerCase(), has_account: true, sales_channel_id: this.salesChannel_ },
       config
@@ -148,7 +152,7 @@ class CustomerService extends MedusaCustomerService {
         delete customer.password
       }
 
-      //else (customer.has_account = false)
+      //else { customer.has_account = false }
 
       debugLog("calling customer.create with props:", "email:", customer.email, "has_account:", customer.has_account, "sales channel id:", customer.sales_channel_id)
 

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -49,7 +49,10 @@ class CustomerService extends MedusaCustomerService {
       customer.email = customer.email.toLowerCase()
 
       // set customer.sales_channel_id using the sales channel registered in middleware
-      if (!customer.sales_channel_id) { customer.sales_channel_id = this.salesChannelID_ }
+      if (!customer.sales_channel_id) { 
+        debugLog ("customer.sales_channel_id not set, assigning with value:", this.salesChannelID_)
+        customer.sales_channel_id = this.salesChannelID_
+      }
 
       const { email, password } = customer
 


### PR DESCRIPTION
Full refactor of the multi-site functionality, now it's quite a simple infra:

- get the Publishable API key and use it to register the sales channel ID to the request scope
- (in auth service) authenticateCustomer was extended to use the sales channel ID to only auth the user for the correct sales channel
- (in customer service) customer create function was extended to set the sales_channel_id and pass the sales channel ID to a function that gets a list of customers to decide whether to create a new one or not
- (in cart service) simply tell it to use the extended customer service create function instead of the core one (so that guest users get the sales channel id assigned with the extended customer.create)